### PR TITLE
Navigate based on Authentication state:

### DIFF
--- a/app/src/main/java/com/example/android/firebaseui_login_sample/LoginFragment.kt
+++ b/app/src/main/java/com/example/android/firebaseui_login_sample/LoginFragment.kt
@@ -20,20 +20,20 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.Observer
-import androidx.navigation.fragment.findNavController
 import androidx.activity.addCallback
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.observe
 import androidx.navigation.NavController
-import com.example.android.firebaseui_login_sample.databinding.*
+import androidx.navigation.fragment.findNavController
+import com.example.android.firebaseui_login_sample.LoginViewModel.AuthenticationState.*
+import com.example.android.firebaseui_login_sample.databinding.FragmentLoginBinding
 import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.IdpResponse
-import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.auth.FirebaseAuth
 
 class LoginFragment : Fragment() {
@@ -50,7 +50,7 @@ class LoginFragment : Fragment() {
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
-    ): View? {
+    ): View {
 
         // Inflate the layout for this fragment.
         val binding = DataBindingUtil.inflate<FragmentLoginBinding>(
@@ -66,6 +66,23 @@ class LoginFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         navController = findNavController()
+
+        // If the user presses the back button from Log in screen, bring them back to the home screen
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            navController.popBackStack(R.id.mainFragment, false)
+        }
+
+        /* If unauthenticated user tries to access Settings screen, they are redirected to the
+         * Login screen and they go through the sign in flow. After the user successfully logs in,
+         * they should be brought back to Settings screen, and not left on Login screen. */
+        viewModel.authenticationState.observe(viewLifecycleOwner) { authenticationState ->
+            when (authenticationState) {
+                // If the user has logged in successfully, bring them back to the settings screen.
+                AUTHENTICATED -> navController.popBackStack()
+                // If the user did not log in successfully, display an error message.
+                else -> Log.e(TAG, "Unauthenticated user")
+            }
+        }
     }
 
     private fun launchSignInFlow() {

--- a/app/src/main/java/com/example/android/firebaseui_login_sample/MainFragment.kt
+++ b/app/src/main/java/com/example/android/firebaseui_login_sample/MainFragment.kt
@@ -20,13 +20,12 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import com.example.android.firebaseui_login_sample.LoginViewModel.AuthenticationState.*
@@ -48,7 +47,7 @@ class MainFragment : Fragment() {
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_main, container, false)
 
         // Remove the two lines below once observeAuthenticationState is implemented.
@@ -65,6 +64,10 @@ class MainFragment : Fragment() {
         binding.authButton.setOnClickListener {
             // Call launchSignInFlow when authButton is clicked
             launchSignInFlow()
+        }
+
+        binding.settingsButton.setOnClickListener {
+            findNavController().navigate(R.id.action_mainFragment_to_settingsFragment)
         }
     }
 

--- a/app/src/main/java/com/example/android/firebaseui_login_sample/SettingsFragment.kt
+++ b/app/src/main/java/com/example/android/firebaseui_login_sample/SettingsFragment.kt
@@ -20,9 +20,10 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
+import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.preference.PreferenceFragmentCompat
+import com.example.android.firebaseui_login_sample.LoginViewModel.AuthenticationState.*
 
 class SettingsFragment : PreferenceFragmentCompat() {
 
@@ -39,5 +40,15 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        /* If an unauthenticated user tries to access Settings screen, they should be redirected
+         * to the Login screen and go through the sign in flow. */
+        viewModel.authenticationState.observe(viewLifecycleOwner) { authenticationState ->
+            when (authenticationState) {
+                AUTHENTICATED -> Log.i(TAG, "Authenticated user")
+                UNAUTHENTICATED -> findNavController().navigate(R.id.loginFragment)
+                else -> Log.i(TAG, "Invalid authentication")
+            }
+        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,7 +23,7 @@
         android:layout_height="match_parent"
         tools:context=".MainActivity">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
             android:id="@+id/nav_host_fragment"
             android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~  Copyright 2019, The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,42 +13,63 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<layout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-            android:layout_height="match_parent">
+        android:layout_height="match_parent">
 
         <TextView
             android:id="@+id/auth_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/text_margin"
+            android:layout_marginStart="8dp"
             android:layout_marginBottom="8dp"
             android:background="@color/colorAccent"
+            android:gravity="center"
             android:padding="@dimen/text_padding"
             android:textColor="@color/white"
             android:textSize="@dimen/button_text_size"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/settings_button"
+            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             tools:text="@string/login_button_text" />
 
         <TextView
-                android:id="@+id/welcome_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/text_padding"
-                android:textAlignment="center"
-                android:textSize="36sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="Android is the world's most popular platform."/>
+            android:id="@+id/settings_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/text_margin"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            android:background="@color/colorAccent"
+            android:gravity="center"
+            android:padding="@dimen/text_padding"
+            android:text="@string/settings_btn"
+            android:textColor="@color/white"
+            android:textSize="@dimen/button_text_size"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/auth_button"
+            tools:text="@string/settings_btn" />
+
+        <TextView
+            android:id="@+id/welcome_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/text_padding"
+            android:textAlignment="center"
+            android:textSize="36sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Android is the world's most popular platform." />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -25,6 +25,9 @@
             android:id="@+id/mainFragment"
             android:name="com.example.android.firebaseui_login_sample.MainFragment"
             android:label="MainFragment">
+        <action
+            android:id="@+id/action_mainFragment_to_settingsFragment"
+            app:destination="@id/settingsFragment" />
     </fragment>
     <fragment
             android:id="@+id/settingsFragment"


### PR DESCRIPTION
1. Prevent access to some screens for unauthenticated users. If an unauthenticated user tries to access Settings screen, they should be redirected to the Login screen and go through the sign in flow.
2. Navigation after successful Login. Show the screen which the user tried to access before logging in, by popping the BackStack.